### PR TITLE
[Refactor] 예외 노출 수정, 공용 패키지가 앱 레이어를 참조하지 않도록 수정

### DIFF
--- a/apps/ai_api/.env.example
+++ b/apps/ai_api/.env.example
@@ -2,10 +2,10 @@ HOST=0.0.0.0
 PORT=9000
 
 # Model paths
-UNET_CHECKPOINT_PATH=c:/capstone2/rf-service/apps/trainer/src/models/unet/best_unet.pth
-UNET_CONFIG_PATH=c:/capstone2/rf-service/apps/ai_api/configs/unet_inference.yaml
-YOLO_MODEL_PATH=c:/capstone2/rf-service/apps/trainer/src/models/yolo/best.pt
-YOLO_CONFIG_PATH=c:/capstone2/rf-service/apps/ai_api/configs/yolo_inference.yaml
+UNET_CHECKPOINT_PATH=apps/trainer/src/models/unet/best_unet.pth
+UNET_CONFIG_PATH=apps/ai_api/configs/unet_inference.yaml
+YOLO_MODEL_PATH=apps/trainer/src/models/yolo/best.pt
+YOLO_CONFIG_PATH=apps/ai_api/configs/yolo_inference.yaml
 
 # Inference runtime
 YOLO_CONF_THRESHOLD=0.25

--- a/apps/ai_api/app/api/errors.py
+++ b/apps/ai_api/app/api/errors.py
@@ -1,4 +1,9 @@
+import logging
+
 from fastapi import HTTPException
+
+
+logger = logging.getLogger(__name__)
 
 
 class AppError(Exception):
@@ -17,4 +22,5 @@ def to_http_exception(exc: Exception) -> HTTPException:
         return HTTPException(status_code=400, detail=str(exc))
     if isinstance(exc, FileNotFoundError):
         return HTTPException(status_code=404, detail=str(exc))
-    return HTTPException(status_code=500, detail=str(exc))
+    logger.exception("Unhandled exception during API request")
+    return HTTPException(status_code=500, detail="Internal Server Error")

--- a/apps/ai_api/configs/yolo_inference.yaml
+++ b/apps/ai_api/configs/yolo_inference.yaml
@@ -1,5 +1,5 @@
 model:
-  weights_path: c:/capstone2/rf-service/apps/trainer/src/models/yolo/best.pt
+  weights_path: apps/trainer/src/models/yolo/best.pt
 
 infer:
   conf_threshold: 0.25

--- a/packages/ai_runtime/yolo_runtime.py
+++ b/packages/ai_runtime/yolo_runtime.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import torch
 from ultralytics import YOLO
 
-from apps.trainer.src.inference_cli.infer_yolo import infer_yolo_array
-
 _YOLO_MODEL = None
 
 
@@ -27,6 +25,24 @@ def load_yolo_runtime(weights_path: str) -> YOLO:
     if _YOLO_MODEL is None:
         _YOLO_MODEL = YOLO(weights_path)
     return _YOLO_MODEL
+
+
+def infer_yolo_array(
+    model: YOLO,
+    image_bgr,
+    *,
+    conf: float = 0.25,
+    device: str = "cpu",
+):
+    """Run YOLO inference for a single BGR image."""
+    results = model.predict(
+        source=image_bgr,
+        imgsz=max(image_bgr.shape[:2]),
+        conf=conf,
+        device=device,
+        verbose=False,
+    )
+    return results[0]
 
 
 def run_yolo_inference_result(

--- a/packages/rf_core/services/rf_run_service.py
+++ b/packages/rf_core/services/rf_run_service.py
@@ -181,7 +181,7 @@ def run_rf(
         simulator = BaselineRfSimulator(scene=scene, ap_layout=layout, config=config)
         result = simulator.run()
 
-        image_url = None if skip_heatmap else _resolve_image_url(rf_run_id)
+        image_url = None
         manifest: dict[str, Any]
         path_bundle: RfOutputPaths | None
         run_output_root_str = ""
@@ -219,6 +219,8 @@ def run_rf(
             manifest_path = str((output_dir / "run_manifest.json").resolve())
             summary_path = str((output_dir / "run_summary.json").resolve())
             heatmap_name = manifest.get("artifacts", {}).get("heatmap_png")
+            if heatmap_name and not skip_heatmap:
+                image_url = _resolve_image_url(rf_run_id)
             heatmap_path = (
                 str((output_dir / heatmap_name).resolve()) if heatmap_name else None
             )


### PR DESCRIPTION
## 수정 요약
- 프로젝트 구조를 모듈 아키텍처로 재구성하여 `FastAPI(apps/ai_api)`, `AI runtime(packages/ai_runtime)`, `RF core(packages/rf_core)` 책임을 분리 마무리
- 리뷰 피드백 반영으로 예외 처리 보안, 패키지 의존성 방향, RF artifact 반환 로직, 경로 설정 이식성을 개선

## 상세 내용
- Unknown exception 응답에서 내부 메시지 노출 제거 (`500: Internal Server Error` 고정, 상세는 서버 로그로 기록).
- `packages/ai_runtime`가 `apps/trainer`를 참조하던 의존성 제거 (`infer_yolo_array`를 runtime 내부로 이동).
- `persist_outputs=False`일 때 존재하지 않는 heatmap URL 반환하던 로직 수정 (실제 artifact 생성 시에만 `imageUrl` 설정).
- `.env.example` 및 YOLO inference config의 절대경로를 상대경로로 변경해 환경 독립성 확보.
