### PR TITLE
SageMaker BYOC entrypoint 수정 및 Async Endpoint 배포

### DIFF
--- a/apps/sagemaker_inference/Dockerfile
+++ b/apps/sagemaker_inference/Dockerfile
@@ -38,6 +38,13 @@ COPY packages /opt/app/packages
 COPY apps/sagemaker_inference/app     /opt/app/app
 COPY apps/sagemaker_inference/schemas /opt/app/schemas
 
+# --- 7. SageMaker BYOC entrypoint ---------------------------------------
+# SageMaker hosting 은 컨테이너를 `docker run <image> serve` 로 띄움.
+# /usr/local/bin/serve 를 ENTRYPOINT 로 둬서 두 케이스 모두 처리.
+# sed: Windows 에서 빌드 컨텍스트를 만든 경우 CRLF 가 섞여 들어오는 걸 방어.
+COPY apps/sagemaker_inference/serve /usr/local/bin/serve
+RUN sed -i 's/\r$//' /usr/local/bin/serve && chmod +x /usr/local/bin/serve
+
 # --- Env ---------------------------------------------------------------
 ENV PYTHONPATH=/opt/app \
     PYTHONUNBUFFERED=1 \
@@ -55,4 +62,6 @@ EXPOSE 8080
 HEALTHCHECK --interval=10s --timeout=4s --start-period=120s --retries=3 \
     CMD curl -fsS http://localhost:8080/ping || exit 1
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "1"]
+# SageMaker 가 `docker run <image> serve` 로 호출하면 ENTRYPOINT 가 받아서 처리.
+# 로컬 `docker run <image>` 도 동일하게 동작.
+ENTRYPOINT ["serve"]

--- a/apps/sagemaker_inference/README.md
+++ b/apps/sagemaker_inference/README.md
@@ -108,6 +108,8 @@ python apps/sagemaker_inference/scripts/run_local_invocation.py \
 - ✅ `/invocations` : POST 본문 처리, JSON 응답
 - ✅ 포트 8080
 - ✅ stderr/stdout 로그 (CloudWatch 자동 수집)
+- ✅ **`docker run <image> serve` 호출 형태 지원** — SageMaker hosting 은 컨테이너를 이 형태로 실행함.
+  `serve` 스크립트가 ENTRYPOINT 로 등록되어 인자를 받아 uvicorn 실행. 로컬 `docker run <image>` 도 동일하게 동작.
 
 ## 환경변수
 

--- a/apps/sagemaker_inference/serve
+++ b/apps/sagemaker_inference/serve
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SageMaker BYOC 는 컨테이너를 `docker run <image> serve` 형태로 실행한다.
+# (참고: https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html)
+#
+# 로컬 `docker run <image>` 에서도 동일하게 동작하도록 serve 인자가 들어오면 무시한다.
+if [ "${1:-}" = "serve" ]; then
+  shift
+fi
+
+exec uvicorn app.main:app \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --workers 1


### PR DESCRIPTION
## 개요

- SageMaker Async Inference 환경에서 AI inference container가 정상적으로 시작되지 않던 문제를 수정 

이번 PR에서는 `serve` entrypoint script를 추가하여 SageMaker BYOC 실행 규약에 맞게 컨테이너가 FastAPI inference server를 실행하도록 수정했습니다.

## 변경 내용

### 1. SageMaker BYOC entrypoint 추가

- `apps/sagemaker_inference/serve` 스크립트 추가
- SageMaker가 전달하는 `serve` 인자를 처리
- 최종적으로 `uvicorn app.main:app --host 0.0.0.0 --port 8080 --workers 1` 실행

### 2. Dockerfile 수정

- `serve` 스크립트를 `/usr/local/bin/serve`로 복사
- Windows CRLF 방지를 위해 `sed -i 's/\r$//'` 처리 추가
- 실행 권한 부여
- 기존 `CMD ["uvicorn", ...]` 제거
- `ENTRYPOINT ["serve"]` 추가

### 3. README 업데이트

- SageMaker hosting이 `docker run <image> serve` 형태로 컨테이너를 실행한다는 점 명시
- `serve` script가 ENTRYPOINT로 등록되어 로컬 실행과 SageMaker 실행을 모두 지원함을 문서화

```text
CannotStartContainerError.
Please ensure the model container for variant AllTraffic starts correctly when invoked with 'docker run <image> serve'

## Deployment Verification
AWS 환경에서 다음 작업 확인
- CodeBuild를 통한 Docker image build 성공
- ECR push 성공
- SageMaker Model 생성 완료
- SageMaker Async Endpoint 생성 완료
- Endpoint status = InService
- Production variant = AllTraffic
- Instance type = ml.g4dn.xlarge
- Auto Scaling 설정 완료
    - MinCapacity = 0
    - MaxCapacity = 1
    - Metric = ApproximateBacklogSizePerInstance
    - TargetValue = 1
  - 무요청 상태에서 scale-to-zero 확인 결과

```JSON
[
  {
    "Variant": "AllTraffic",
    "Current": 0,
    "Desired": 0,
    "Status": null
  }
]
```

## Scope
### Included
- SageMaker BYOC entrypoint fix
- Dockerfile update

### Not Included
- Backend AI Job 연동
- S3 input/output E2E inference request test
- IaC/Terraform/CDK 자동화

## Next Step
- SageMaker Async Endpoint에 테스트 input.json 요청
- S3 output/result.json 생성 확인
- Backend에서 InvokeEndpointAsync 호출 로직 구현
- AI Job 상태 관리 API 연동
- 사용 후 endpoint teardown 절차 문서화