### PR TITLE
[Refactor] Sionna RT 결과 이미지 서빙 및 heatmap artifact 응답 구조 개선

### DIFF
--- a/apps/ai_api/Dockerfile
+++ b/apps/ai_api/Dockerfile
@@ -1,0 +1,48 @@
+FROM tensorflow/tensorflow:2.16.1-gpu
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONPATH=/opt/app \
+    HOST=0.0.0.0 \
+    PORT=9000 \
+    DEFAULT_DEVICE=auto \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics \
+    NVIDIA_VISIBLE_DEVICES=all \
+    MITSUBA_VARIANT=cuda_ad_mono_polarized \
+    LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu
+
+WORKDIR /opt/app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libgl1 \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY apps/ai_api/requirements.txt /tmp/requirements.txt
+COPY apps/ai_api/requirements-rf.txt /tmp/requirements-rf.txt
+
+RUN python -m pip install --upgrade pip \
+    && pip install -r /tmp/requirements.txt \
+    && pip install -r /tmp/requirements-rf.txt
+
+COPY packages /opt/app/packages
+COPY apps/ai_api /opt/app/apps/ai_api
+
+RUN mkdir -p /opt/app/apps/ai_api/data/output
+
+WORKDIR /opt/app/apps/ai_api
+
+EXPOSE 9000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1
+
+CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-9000}"]

--- a/apps/ai_api/app/api/routes/sionna.py
+++ b/apps/ai_api/app/api/routes/sionna.py
@@ -1,12 +1,21 @@
-"""내부 Sionna 실행 API (인증·DB 본연동 없음, sionna_rt 기본)."""
+"""내부 Sionna 실행 API (인증·DB 본연동 없음, sionna_rt 기본).
+
+이미지 서빙 라우트도 같이 제공 — Sionna 결과 PNG (heatmap/valid_mask/geometry_overlay) 를
+브라우저가 직접 로드할 수 있도록 GET /internal/sionna/images/{sionna_run_id}/{filename} 노출.
+"""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
 
 from app.api.error_normalizers.sionna import normalize_sionna_exception
 from app.api.error_responses.sionna import SIONNA_ERROR_RESPONSES
 from app.infrastructure.ai_runtime.sionna_gateway import run_sionna_with_runtime
+from app.infrastructure.settings import OUTPUT_DIR
 from app.presentation.requests.sionna_request_dto import SionnaRunRequestDto
 from app.presentation.responses.sionna_response_dto import (
     SionnaRunResponseDto,
@@ -15,6 +24,16 @@ from app.presentation.responses.sionna_response_dto import (
 from app.usecases.run_sionna_usecase import run_sionna_usecase
 
 router = APIRouter()
+
+# UUID4 형식만 허용 — path traversal 방어 (../ 등 차단).
+_RUN_ID_PATTERN = re.compile(r"^[0-9a-fA-F\-]{8,64}$")
+# 서빙 가능한 파일 화이트리스트.
+_ALLOWED_FILES = {
+    "radiomap_heatmap.png",            # clean overlay (캔버스 정렬용)
+    "radiomap_heatmap_annotated.png",  # 디버그/사람 보기용 (chrome 포함)
+    "valid_mask.png",
+    "geometry_overlay.png",
+}
 
 
 @router.post(
@@ -28,3 +47,31 @@ def post_internal_sionna_run(body: SionnaRunRequestDto) -> SionnaRunResponseDto:
     except Exception as exc:
         raise normalize_sionna_exception(exc, body=body) from exc
     return to_sionna_response(result)
+
+
+@router.get(
+    "/sionna/images/{sionna_run_id}.png",
+    summary="Sionna RT heatmap PNG 직접 다운로드 (default: radiomap_heatmap.png)",
+)
+def get_sionna_heatmap_image(sionna_run_id: str) -> FileResponse:
+    """기본 heatmap PNG. backend / 프론트가 <img src> 로 직접 로드."""
+    return _serve_sionna_artifact(sionna_run_id, "radiomap_heatmap.png")
+
+
+@router.get(
+    "/sionna/images/{sionna_run_id}/{filename}",
+    summary="Sionna RT 결과 PNG 명시적 파일명",
+)
+def get_sionna_artifact_image(sionna_run_id: str, filename: str) -> FileResponse:
+    return _serve_sionna_artifact(sionna_run_id, filename)
+
+
+def _serve_sionna_artifact(sionna_run_id: str, filename: str) -> FileResponse:
+    if not _RUN_ID_PATTERN.match(sionna_run_id):
+        raise HTTPException(status_code=400, detail="invalid sionna_run_id format")
+    if filename not in _ALLOWED_FILES:
+        raise HTTPException(status_code=404, detail=f"file not allowed: {filename}")
+    path: Path = OUTPUT_DIR / "sionna" / "sionna_rt" / sionna_run_id / filename
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail=f"artifact not found: {filename}")
+    return FileResponse(path, media_type="image/png")

--- a/apps/ai_api/app/domain/entities/radio/simulation_config.py
+++ b/apps/ai_api/app/domain/entities/radio/simulation_config.py
@@ -1,3 +1,13 @@
+"""ai_api 도메인의 SimulationConfig.
+
+⚠️ web-platform 경로에서의 source of truth 는 여기가 아님:
+   `web-platform/backend/app/core/rf_defaults.py`
+
+web-platform 의 `rf_backend_local._build_sionna_request_payload` 가 모든 sub-config
+(physical / solver / propagation) 를 명시적으로 채워서 보내므로 이 모듈의 Field default
+는 사용되지 않는다. 단, ai_api `/internal/sionna/run` 을 직접 호출하는 다른 클라이언트
+(테스트/CLI 등) 에선 fallback 으로 동작. 혼선 방지 위해 rf_defaults.py 와 **같은 값** 유지.
+"""
 from __future__ import annotations
 
 from pydantic import BaseModel, Field

--- a/apps/ai_api/app/domain/entities/radio/simulation_config.py
+++ b/apps/ai_api/app/domain/entities/radio/simulation_config.py
@@ -22,8 +22,8 @@ class PropagationConfig(BaseModel):
     los: bool = True
     specular_reflection: bool = True
     refraction: bool = True
-    diffuse_reflection: bool = False
-    diffraction: bool = False
+    diffuse_reflection: bool = True
+    diffraction: bool = True
 
 
 class SolverConfig(BaseModel):

--- a/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
+++ b/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
@@ -1,4 +1,16 @@
-"""Sionna 결과의 시각화/JSON 아티팩트 생성·디스크 저장."""
+"""Sionna 결과의 시각화/JSON 아티팩트 생성·디스크 저장.
+
+## Thread safety
+
+`matplotlib.pyplot` 사용 X — pyplot 은 전역 figure registry + "current figure" 포인터를
+관리하는 stateful module 이라 FastAPI sync route 가 thread pool 에서 동시 호출되면
+race condition (figure mix-up, 메모리 누수) 가능.
+
+→ OO API (`matplotlib.figure.Figure` + 명시적 `FigureCanvasAgg`) 만 사용. Figure 객체는
+   함수 local scope 라 thread 간 격리, GC 도 자동 (pyplot 의 close() 불필요).
+
+`matplotlib.use("Agg")` 도 필요 없음 — `FigureCanvasAgg` 를 직접 박으므로.
+"""
 
 from __future__ import annotations
 
@@ -6,15 +18,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-# matplotlib backend을 GUI 없는 Agg 로 강제 — FastAPI sync route 가 thread pool 에서
-# 실행돼서 main thread 가 아니므로 TkAgg 기본값은 "Starting Matplotlib GUI outside main
-# thread" 경고 + 종료 시 tkinter cleanup RuntimeError 를 일으킴. Agg 는 디스크 저장만
-# 하므로 thread-safe. plt 임포트 전에 호출해야 함.
-import matplotlib
-matplotlib.use("Agg")
-
-import matplotlib.pyplot as plt
+import matplotlib as mpl
 import numpy as np
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
 
@@ -180,6 +187,17 @@ def _output_dir(sionna_run_id: str) -> Path:
     return out_dir
 
 
+def _new_figure(figsize: tuple[float, float], dpi: int = 100) -> Figure:
+    """Thread-safe figure 생성 — Agg canvas 명시적으로 연결, pyplot 안 거침.
+
+    pyplot 의 전역 figure registry/current-figure 포인터를 안 건드리므로 thread 간 race
+    없음. canvas 가 fig.canvas 로 접근 가능 (matplotlib 이 자동 연결).
+    """
+    fig = Figure(figsize=figsize, dpi=dpi)
+    FigureCanvasAgg(fig)  # canvas 를 fig 에 attach (생성자가 fig.canvas 로 등록)
+    return fig
+
+
 def save_radiomap_png(
     sionna_run_id: str,
     radiomap_dbm: list[list[float]],
@@ -204,7 +222,7 @@ def save_radiomap_png(
         valid_values = arr[arr > INVALID_DBM_THRESHOLD]
         vmin, vmax = _resolve_auto_color_limits(valid_values, visualization_cfg)
         masked = np.ma.masked_where(arr <= INVALID_DBM_THRESHOLD, arr)
-        cmap = plt.get_cmap("inferno").copy()
+        cmap = mpl.colormaps["inferno"].copy()
         cmap.set_bad(color="#5a5a5a", alpha=0.0)  # invalid 셀은 투명 — 캔버스 배경 노출
 
         out_dir = _output_dir(sionna_run_id)
@@ -215,7 +233,8 @@ def save_radiomap_png(
         overlay_path = out_dir / "radiomap_heatmap.png"
         h, w = arr.shape
         # 데이터 한 셀당 픽셀 1:1 보존 (interpolation 은 SVG/브라우저가 알아서 늘림).
-        fig_overlay, ax_overlay = plt.subplots(figsize=(w / 100.0, h / 100.0), dpi=100)
+        fig_overlay = _new_figure(figsize=(w / 100.0, h / 100.0), dpi=100)
+        ax_overlay = fig_overlay.subplots()
         ax_overlay.imshow(
             masked,
             cmap=cmap,
@@ -228,12 +247,12 @@ def save_radiomap_png(
         fig_overlay.savefig(
             overlay_path, dpi=100, bbox_inches="tight", pad_inches=0, transparent=True
         )
-        plt.close(fig_overlay)
 
         # (2) Annotated debug — 사람 보기용 (현재 캔버스에는 안 깔림).
         annotated_path = out_dir / "radiomap_heatmap_annotated.png"
-        fig_ann, ax_ann = plt.subplots(figsize=(7.2, 5.4))
-        cmap_ann = plt.get_cmap("inferno").copy()
+        fig_ann = _new_figure(figsize=(7.2, 5.4))
+        ax_ann = fig_ann.subplots()
+        cmap_ann = mpl.colormaps["inferno"].copy()
         cmap_ann.set_bad(color="#5a5a5a", alpha=1.0)
         im = ax_ann.imshow(
             masked,
@@ -261,9 +280,8 @@ def save_radiomap_png(
             "Gray = not simulated / invalid cell",
             fontsize=8, color="#444444",
         )
-        plt.tight_layout()
-        plt.savefig(annotated_path, dpi=150)
-        plt.close(fig_ann)
+        fig_ann.tight_layout()
+        fig_ann.savefig(annotated_path, dpi=150)
 
         return str(overlay_path.resolve())
     except Exception:
@@ -273,7 +291,8 @@ def save_radiomap_png(
 def save_valid_mask_png(sionna_run_id: str, valid_mask: np.ndarray) -> str | None:
     try:
         out_path = _output_dir(sionna_run_id) / "valid_mask.png"
-        fig, ax = plt.subplots(figsize=(7.2, 5.4))
+        fig = _new_figure(figsize=(7.2, 5.4))
+        ax = fig.subplots()
         ax.imshow(valid_mask.astype(float), origin="lower", cmap="gray", vmin=0.0, vmax=1.0, interpolation="nearest")
         ax.set_title("Valid Cell Mask (white=valid)")
         ax.set_xlabel("X grid")
@@ -287,9 +306,8 @@ def save_valid_mask_png(sionna_run_id: str, valid_mask: np.ndarray) -> str | Non
             fontsize=7,
             framealpha=0.75,
         )
-        plt.tight_layout()
-        plt.savefig(out_path, dpi=140)
-        plt.close(fig)
+        fig.tight_layout()
+        fig.savefig(out_path, dpi=140)
         return str(out_path.resolve())
     except Exception:
         return None
@@ -306,7 +324,8 @@ def save_geometry_overlay_png(
 ) -> str | None:
     try:
         out_path = _output_dir(sionna_run_id) / "geometry_overlay.png"
-        fig, ax = plt.subplots(figsize=(7.2, 5.4))
+        fig = _new_figure(figsize=(7.2, 5.4))
+        ax = fig.subplots()
         base = np.zeros((height, width), dtype=float)
         ax.imshow(base, origin="lower", cmap="gray", vmin=0.0, vmax=1.0)
         _draw_scene_overlay(
@@ -320,9 +339,8 @@ def save_geometry_overlay_png(
         ax.set_title("Geometry Debug Overlay")
         ax.set_xlabel("X grid")
         ax.set_ylabel("Y grid")
-        plt.tight_layout()
-        plt.savefig(out_path, dpi=140)
-        plt.close(fig)
+        fig.tight_layout()
+        fig.savefig(out_path, dpi=140)
         return str(out_path.resolve())
     except Exception:
         return None

--- a/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
+++ b/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
@@ -6,6 +6,13 @@ import json
 from pathlib import Path
 from typing import Any
 
+# matplotlib backend을 GUI 없는 Agg 로 강제 — FastAPI sync route 가 thread pool 에서
+# 실행돼서 main thread 가 아니므로 TkAgg 기본값은 "Starting Matplotlib GUI outside main
+# thread" 경고 + 종료 시 tkinter cleanup RuntimeError 를 일으킴. Agg 는 디스크 저장만
+# 하므로 thread-safe. plt 임포트 전에 호출해야 함.
+import matplotlib
+matplotlib.use("Agg")
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.lines import Line2D

--- a/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
+++ b/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
@@ -17,6 +17,20 @@ from app.infrastructure.settings import OUTPUT_DIR
 INVALID_DBM_THRESHOLD = -200.0
 
 
+def resolve_radiomap_color_limits(
+    radiomap_dbm: list[list[float]] | np.ndarray,
+    visualization_cfg: dict[str, Any] | None = None,
+) -> tuple[float, float]:
+    """이 run 의 heatmap auto color scale (p5-p95) — sionna_gateway 등 외부에서 사용.
+
+    invalid 셀 (값 <= INVALID_DBM_THRESHOLD) 은 제외하고 percentile 계산.
+    valid 값이 비었거나 spread 가 너무 좁으면 fallback (cfg 의 -90/-30 등) 사용.
+    """
+    arr = np.asarray(radiomap_dbm, dtype=float)
+    valid = arr[arr > INVALID_DBM_THRESHOLD]
+    return _resolve_auto_color_limits(valid, visualization_cfg)
+
+
 def _resolve_auto_color_limits(
     valid_values: np.ndarray,
     visualization_cfg: dict[str, Any] | None = None,
@@ -168,41 +182,83 @@ def save_radiomap_png(
     bounds: dict[str, Any],
     visualization_cfg: dict[str, Any] | None = None,
 ) -> str | None:
+    """Sionna RadioMap → 2 개의 PNG 동시 저장.
+
+      1) radiomap_heatmap.png : **clean overlay (chrome 없음)** + image 규약 y (top=row0).
+         프론트 캔버스의 `<image>` 가 floor 좌표에 1:1 정렬해서 깔려야 하므로 이게 1차.
+
+      2) radiomap_heatmap_annotated.png : 디버그/사람 보기용 (제목/축/colorbar/legend 포함).
+         physics 규약(origin=lower) + scene overlay (벽/AP/문 등). 검증용 — 캔버스 X.
+
+    이전엔 (2) 형식만 저장해서 chrome 도 캔버스에 깔리고 Y축이 뒤집혀 보였음 (#bugfix).
+    """
     try:
         arr = np.asarray(radiomap_dbm, dtype=float)
         valid_values = arr[arr > INVALID_DBM_THRESHOLD]
         vmin, vmax = _resolve_auto_color_limits(valid_values, visualization_cfg)
         masked = np.ma.masked_where(arr <= INVALID_DBM_THRESHOLD, arr)
-        out_path = _output_dir(sionna_run_id) / "radiomap_heatmap.png"
-        fig, ax = plt.subplots(figsize=(7.2, 5.4))
         cmap = plt.get_cmap("inferno").copy()
-        cmap.set_bad(color="#5a5a5a", alpha=1.0)
-        im = ax.imshow(
+        cmap.set_bad(color="#5a5a5a", alpha=0.0)  # invalid 셀은 투명 — 캔버스 배경 노출
+
+        out_dir = _output_dir(sionna_run_id)
+
+        # (1) Clean overlay — 캔버스 정렬용.
+        # default origin (= 'upper'): PNG row 0 = data row 0 → SVG y=minY (top) 에 그려져
+        # walls/AP 의 image 규약 (y=0 이 top) 와 정확히 일치.
+        overlay_path = out_dir / "radiomap_heatmap.png"
+        h, w = arr.shape
+        # 데이터 한 셀당 픽셀 1:1 보존 (interpolation 은 SVG/브라우저가 알아서 늘림).
+        fig_overlay, ax_overlay = plt.subplots(figsize=(w / 100.0, h / 100.0), dpi=100)
+        ax_overlay.imshow(
+            masked,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            interpolation="nearest",
+        )
+        ax_overlay.axis("off")
+        fig_overlay.subplots_adjust(left=0, right=1, top=1, bottom=0)
+        fig_overlay.savefig(
+            overlay_path, dpi=100, bbox_inches="tight", pad_inches=0, transparent=True
+        )
+        plt.close(fig_overlay)
+
+        # (2) Annotated debug — 사람 보기용 (현재 캔버스에는 안 깔림).
+        annotated_path = out_dir / "radiomap_heatmap_annotated.png"
+        fig_ann, ax_ann = plt.subplots(figsize=(7.2, 5.4))
+        cmap_ann = plt.get_cmap("inferno").copy()
+        cmap_ann.set_bad(color="#5a5a5a", alpha=1.0)
+        im = ax_ann.imshow(
             masked,
             origin="lower",
-            cmap=cmap,
+            cmap=cmap_ann,
             vmin=vmin,
             vmax=vmax,
             interpolation="bicubic",
         )
         _draw_scene_overlay(
-            ax,
+            ax_ann,
             scene_plan=scene_plan,
             antenna=antenna,
             bounds=bounds,
             width=arr.shape[1],
             height=arr.shape[0],
         )
-        ax.set_title("Sionna RT RadioMap")
-        ax.set_xlabel("X grid")
-        ax.set_ylabel("Y grid")
-        cbar = fig.colorbar(im, ax=ax)
+        ax_ann.set_title("Sionna RT RadioMap (debug)")
+        ax_ann.set_xlabel("X grid")
+        ax_ann.set_ylabel("Y grid")
+        cbar = fig_ann.colorbar(im, ax=ax_ann)
         cbar.set_label(f"RSS (dBm), auto scale p5-p95 [{vmin:.1f}, {vmax:.1f}]")
-        fig.text(0.02, 0.01, "Gray = not simulated / invalid cell", fontsize=8, color="#444444")
+        fig_ann.text(
+            0.02, 0.01,
+            "Gray = not simulated / invalid cell",
+            fontsize=8, color="#444444",
+        )
         plt.tight_layout()
-        plt.savefig(out_path, dpi=150)
-        plt.close(fig)
-        return str(out_path.resolve())
+        plt.savefig(annotated_path, dpi=150)
+        plt.close(fig_ann)
+
+        return str(overlay_path.resolve())
     except Exception:
         return None
 
@@ -285,6 +341,7 @@ def save_runtime_result_json(sionna_run_id: str, runtime_result: dict[str, Any])
 
 __all__ = [
     "INVALID_DBM_THRESHOLD",
+    "resolve_radiomap_color_limits",
     "save_radiomap_png",
     "save_valid_mask_png",
     "save_geometry_overlay_png",

--- a/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
+++ b/apps/ai_api/app/infrastructure/ai_runtime/sionna_artifacts.py
@@ -29,6 +29,7 @@ from app.infrastructure.ai_runtime.sionna_geometry import to_grid_xy
 from app.infrastructure.settings import OUTPUT_DIR
 
 INVALID_DBM_THRESHOLD = -200.0
+RADIOMAP_CMAP = "jet"
 
 
 def resolve_radiomap_color_limits(
@@ -222,7 +223,7 @@ def save_radiomap_png(
         valid_values = arr[arr > INVALID_DBM_THRESHOLD]
         vmin, vmax = _resolve_auto_color_limits(valid_values, visualization_cfg)
         masked = np.ma.masked_where(arr <= INVALID_DBM_THRESHOLD, arr)
-        cmap = mpl.colormaps["inferno"].copy()
+        cmap = mpl.colormaps[RADIOMAP_CMAP].copy()
         cmap.set_bad(color="#5a5a5a", alpha=0.0)  # invalid 셀은 투명 — 캔버스 배경 노출
 
         out_dir = _output_dir(sionna_run_id)
@@ -252,7 +253,7 @@ def save_radiomap_png(
         annotated_path = out_dir / "radiomap_heatmap_annotated.png"
         fig_ann = _new_figure(figsize=(7.2, 5.4))
         ax_ann = fig_ann.subplots()
-        cmap_ann = mpl.colormaps["inferno"].copy()
+        cmap_ann = mpl.colormaps[RADIOMAP_CMAP].copy()
         cmap_ann.set_bad(color="#5a5a5a", alpha=1.0)
         im = ax_ann.imshow(
             masked,

--- a/apps/ai_api/app/infrastructure/ai_runtime/sionna_gateway.py
+++ b/apps/ai_api/app/infrastructure/ai_runtime/sionna_gateway.py
@@ -10,6 +10,7 @@ import numpy as np
 from app.infrastructure.ai_runtime.sionna_adapter import build_engine_plan
 from app.infrastructure.ai_runtime.sionna_artifacts import (
     INVALID_DBM_THRESHOLD,
+    resolve_radiomap_color_limits,
     save_geometry_debug_json,
     save_geometry_overlay_png,
     save_radiomap_png,
@@ -172,12 +173,24 @@ def _build_artifacts(
     paths: dict[str, str | None],
     geometry_debug_payload: dict[str, Any],
 ) -> dict[str, Any]:
+    # 저장된 heatmap PNG 와 동일한 vmin/vmax 를 응답에 포함 → 프론트가 colorbar 를
+    # 정확히 같은 스케일로 표시. visualization_cfg 가 fallback/percentile 결정.
+    visualization_cfg = dict((sionna_result.get("config") or {}).get("visualization") or {})
+    vmin_dbm, vmax_dbm = resolve_radiomap_color_limits(
+        sionna_result["radiomap_dbm"], visualization_cfg,
+    )
     artifacts: dict[str, Any] = {
         "engine": "sionna_rt",
         "radiomap": {
             "grid_shape": sionna_result["grid_shape"],
             "bounds_m": sionna_result["bounds_m"],
             "values_dbm": sionna_result["radiomap_dbm"],
+            "color_scale": {
+                "vmin_dbm": float(vmin_dbm),
+                "vmax_dbm": float(vmax_dbm),
+                "cmap": "inferno",
+                "invalid_color": "transparent",
+            },
         },
         "rssi": {
             **sionna_result["rss_dbm"],

--- a/apps/ai_api/app/infrastructure/ai_runtime/sionna_gateway.py
+++ b/apps/ai_api/app/infrastructure/ai_runtime/sionna_gateway.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+import time
 import uuid
 from typing import Any
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 from app.infrastructure.ai_runtime.sionna_adapter import build_engine_plan
 from app.infrastructure.ai_runtime.sionna_artifacts import (

--- a/apps/ai_api/app/infrastructure/ai_runtime/sionna_gateway.py
+++ b/apps/ai_api/app/infrastructure/ai_runtime/sionna_gateway.py
@@ -192,7 +192,7 @@ def _build_artifacts(
             "color_scale": {
                 "vmin_dbm": float(vmin_dbm),
                 "vmax_dbm": float(vmax_dbm),
-                "cmap": "inferno",
+                "cmap": "jet",
                 "invalid_color": "transparent",
             },
         },

--- a/apps/ai_api/app/main.py
+++ b/apps/ai_api/app/main.py
@@ -1,4 +1,7 @@
+import os
+
 from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 
@@ -10,6 +13,24 @@ from app.infrastructure.ai_runtime.yolo_gateway import preload_yolo_model
 from app.infrastructure.settings import preload_models
 
 app = FastAPI(title="capstone2-ai", version="0.1.0")
+
+# CORS — 프론트엔드(:5173) 가 /internal/sionna/images/* 등을 <img> 로 직접 로드할 때 필요.
+# 또한 backend (:8000) 가 일부 endpoint 를 호출할 수도 있어 같이 허용.
+# env 로 origin 커스터마이즈 가능 (콤마 구분), 기본은 dev 포트들.
+_default_origins = "http://localhost:5173,http://localhost:8000"
+_origins = [
+    o.strip()
+    for o in os.getenv("CORS_ALLOW_ORIGINS", _default_origins).split(",")
+    if o.strip()
+]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(inference_router)
 app.include_router(sionna_router, prefix="/internal", tags=["internal"])
 

--- a/apps/ai_api/app/main.py
+++ b/apps/ai_api/app/main.py
@@ -1,4 +1,13 @@
+import logging
 import os
+
+# 앱 로거 활성화 — module-level `logger.info()` 가 콘솔에 보이도록.
+# force=True: uvicorn 이 이미 root logger 에 handler 를 박았을 경우 덮어쓰기.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    force=True,
+)
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware

--- a/apps/ai_api/app/presentation/responses/sionna_response_dto.py
+++ b/apps/ai_api/app/presentation/responses/sionna_response_dto.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Literal
 
 from pydantic import BaseModel
+
+# imageUrl 템플릿 — env 로 ai_api 의 외부 노출 URL prefix 를 받는다.
+# 예: http://localhost:9000/internal/sionna/images/{sionna_run_id}.png
+# 미지정 시 기본값으로 :9000 가정 (ai_api 의 README/.env 기본 포트).
+_DEFAULT_IMAGE_URL_TEMPLATE = (
+    "http://localhost:9000/internal/sionna/images/{sionna_run_id}.png"
+)
+
+
+def _image_url_template() -> str:
+    return os.getenv("SIONNA_ARTIFACT_IMAGE_URL_TEMPLATE", _DEFAULT_IMAGE_URL_TEMPLATE)
 
 
 class SionnaRunResponseDto(BaseModel):
@@ -15,16 +27,32 @@ class SionnaRunResponseDto(BaseModel):
 
 
 def to_sionna_response(result: dict[str, Any]) -> SionnaRunResponseDto:
+    """artifacts → DTO 변환. imageUrl 은 SIONNA_ARTIFACT_IMAGE_URL_TEMPLATE 기반의
+    실제 HTTP URL — 로컬 FS 경로(visualization_path) 가 아님. 클라이언트가 <img src>
+    로 바로 로드 가능.
+    """
     artifacts = result.get("artifacts") or None
-    image_url = None
+    sionna_run_id = str(result.get("sionna_run_id", ""))
+    status = str(result.get("status", "failed"))
+
+    image_url: str | None = None
     if artifacts is not None:
-        image_url = artifacts.get("imageUrl")
-        if image_url is None:
-            image_url = artifacts.get("visualization_path")
+        # artifacts 에 미리 박힌 imageUrl 이 있으면 그걸 우선 사용 (테스트/오버라이드용).
+        explicit = artifacts.get("imageUrl")
+        if isinstance(explicit, str) and explicit:
+            image_url = explicit
+
+    # 결과가 성공이고 sionna_run_id 가 있으면 env 템플릿으로 URL 구성.
+    # visualization_path (로컬 FS 경로) 는 클라이언트가 못 쓰므로 fallback 으로 안 씀.
+    if image_url is None and status == "succeeded" and sionna_run_id:
+        try:
+            image_url = _image_url_template().format(sionna_run_id=sionna_run_id)
+        except (KeyError, IndexError):
+            image_url = None
 
     return SionnaRunResponseDto(
-        sionna_run_id=str(result.get("sionna_run_id", "")),
-        status=str(result.get("status", "failed")),
+        sionna_run_id=sionna_run_id,
+        status=status,
         metrics=result.get("metrics"),
         artifacts=artifacts,
         imageUrl=image_url,

--- a/scripts/deploy_rf_service.ps1
+++ b/scripts/deploy_rf_service.ps1
@@ -5,9 +5,11 @@ param(
     [string]$User = "ubuntu",
     [string]$KeyPath = "..\..\github-actions-wifi-backend",
     [string]$RemoteRoot = "/opt/rf-service",
-    [string]$ServiceName = "rf-service",
+    [string]$ImageName = "rf-service-ai-api",
+    [string]$ContainerName = "rf-service-ai-api",
     [int]$Port = 9000,
-    [string]$EnvFile = ".env"
+    [string]$EnvFile = ".env",
+    [string]$Gpus = "all"
 )
 
 $ErrorActionPreference = "Stop"
@@ -24,8 +26,8 @@ Require-Command scp
 Require-Command tar
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
-$archive = Join-Path ([System.IO.Path]::GetTempPath()) ("rf-service-deploy-{0}.tar.gz" -f ([guid]::NewGuid().ToString("N")))
-$remoteArchive = "/tmp/rf-service-deploy.tar.gz"
+$archive = Join-Path ([System.IO.Path]::GetTempPath()) ("rf-service-docker-deploy-{0}.tar.gz" -f ([guid]::NewGuid().ToString("N")))
+$remoteArchive = "/tmp/rf-service-docker-deploy.tar.gz"
 $sshTarget = "$User@$HostName"
 $keyCandidate = if ([System.IO.Path]::IsPathRooted($KeyPath)) {
     $KeyPath
@@ -35,7 +37,7 @@ $keyCandidate = if ([System.IO.Path]::IsPathRooted($KeyPath)) {
 $resolvedKey = Resolve-Path $keyCandidate
 $envPath = Join-Path $repoRoot $EnvFile
 
-Write-Host "[rf-service] packaging $repoRoot"
+Write-Host "[rf-service] packaging Docker build context: $repoRoot"
 Push-Location $repoRoot
 try {
     tar `
@@ -57,62 +59,62 @@ if (Test-Path $envPath) {
     Write-Host "[rf-service] uploading env file $EnvFile"
     scp -i $resolvedKey $envPath "${sshTarget}:/tmp/rf-service.env"
 } else {
-    Write-Host "[rf-service] env file not found, remote existing .env will be kept: $envPath"
+    Write-Host "[rf-service] env file not found, remote existing env will be kept: $envPath"
+}
+
+$gpuRunArg = ""
+if ($Gpus -and $Gpus.Trim().ToLowerInvariant() -notin @("none", "false", "0", "off")) {
+    $gpuRunArg = "--gpus $Gpus"
 }
 
 $remoteScript = @"
 set -euo pipefail
-if ! command -v python3 >/dev/null 2>&1; then
-  sudo apt-get update
-  sudo apt-get install -y python3 python3-venv python3-pip
-elif ! python3 -m venv --help >/dev/null 2>&1; then
-  sudo apt-get update
-  sudo apt-get install -y python3-venv python3-pip
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required on the instance. Install Docker first." >&2
+  exit 1
 fi
+
 sudo mkdir -p "$RemoteRoot"
 sudo tar -xzf "$remoteArchive" -C "$RemoteRoot"
 sudo chown -R "${User}:${User}" "$RemoteRoot"
-cd "$RemoteRoot/apps/ai_api"
-python3 -m venv .venv
-. .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -r requirements.txt
-if [ -f requirements-rf.txt ]; then pip install -r requirements-rf.txt; fi
+
 if [ -f /tmp/rf-service.env ]; then
-  mv /tmp/rf-service.env "$RemoteRoot/apps/ai_api/.env"
+  sudo mv /tmp/rf-service.env "$RemoteRoot/.env"
+  sudo chown "${User}:${User}" "$RemoteRoot/.env"
+elif [ ! -f "$RemoteRoot/.env" ]; then
+  cp "$RemoteRoot/.env.example" "$RemoteRoot/.env"
 fi
-sudo tee /etc/systemd/system/$ServiceName.service >/dev/null <<'UNIT'
-[Unit]
-Description=WiFi Capstone RF/AI API
-After=network.target
 
-[Service]
-Type=simple
-WorkingDirectory=$RemoteRoot/apps/ai_api
-EnvironmentFile=-$RemoteRoot/apps/ai_api/.env
-Environment=HOST=0.0.0.0
-Environment=PORT=$Port
-ExecStart=$RemoteRoot/apps/ai_api/.venv/bin/python -m uvicorn main:app --host 0.0.0.0 --port $Port
-Restart=always
-RestartSec=5
+mkdir -p "$RemoteRoot/apps/ai_api/data/output"
 
-[Install]
-WantedBy=multi-user.target
-UNIT
-sudo systemctl daemon-reload
-sudo systemctl enable $ServiceName
-sudo systemctl restart $ServiceName
-sudo systemctl --no-pager --full status $ServiceName
-sleep 2
-curl -fsS "http://127.0.0.1:$Port/health" >/dev/null || {
-  echo "Health check failed. Recent logs:"
-  sudo journalctl -u $ServiceName -n 80 --no-pager
+cd "$RemoteRoot"
+docker build -f apps/ai_api/Dockerfile -t "${ImageName}:latest" .
+
+docker rm -f "$ContainerName" >/dev/null 2>&1 || true
+docker run -d \
+  --name "$ContainerName" \
+  --restart unless-stopped \
+  $gpuRunArg \
+  --env-file "$RemoteRoot/.env" \
+  -e HOST=0.0.0.0 \
+  -e PORT=$Port \
+  -p "${Port}:${Port}" \
+  -v "${RemoteRoot}/apps/ai_api/data/output:/opt/app/apps/ai_api/data/output" \
+  "${ImageName}:latest"
+
+sleep 5
+curl -fsS "http://127.0.0.1:${Port}/health" >/dev/null || {
+  echo "Health check failed. Recent container logs:"
+  docker logs --tail 120 "$ContainerName" || true
   exit 1
 }
+
+docker ps --filter "name=$ContainerName"
 "@
 
-Write-Host "[rf-service] installing and restarting service"
+Write-Host "[rf-service] building and restarting Docker container"
 $remoteScript | ssh -i $resolvedKey $sshTarget "bash -s"
 
 Remove-Item -LiteralPath $archive -Force
-Write-Host "[rf-service] deployed: http://${HostName}:$Port"
+Write-Host "[rf-service] deployed container: http://${HostName}:$Port"

--- a/scripts/deploy_rf_service.ps1
+++ b/scripts/deploy_rf_service.ps1
@@ -1,0 +1,118 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$HostName,
+
+    [string]$User = "ubuntu",
+    [string]$KeyPath = "..\..\github-actions-wifi-backend",
+    [string]$RemoteRoot = "/opt/rf-service",
+    [string]$ServiceName = "rf-service",
+    [int]$Port = 9000,
+    [string]$EnvFile = ".env"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $Name"
+    }
+}
+
+Require-Command ssh
+Require-Command scp
+Require-Command tar
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$archive = Join-Path ([System.IO.Path]::GetTempPath()) ("rf-service-deploy-{0}.tar.gz" -f ([guid]::NewGuid().ToString("N")))
+$remoteArchive = "/tmp/rf-service-deploy.tar.gz"
+$sshTarget = "$User@$HostName"
+$keyCandidate = if ([System.IO.Path]::IsPathRooted($KeyPath)) {
+    $KeyPath
+} else {
+    Join-Path $PSScriptRoot $KeyPath
+}
+$resolvedKey = Resolve-Path $keyCandidate
+$envPath = Join-Path $repoRoot $EnvFile
+
+Write-Host "[rf-service] packaging $repoRoot"
+Push-Location $repoRoot
+try {
+    tar `
+        --exclude ".git" `
+        --exclude ".venv" `
+        --exclude "apps/ai_api/.venv" `
+        --exclude ".ruff_cache" `
+        --exclude "__pycache__" `
+        --exclude "apps/data/output" `
+        -czf $archive .
+} finally {
+    Pop-Location
+}
+
+Write-Host "[rf-service] uploading archive to $sshTarget"
+scp -i $resolvedKey $archive "${sshTarget}:${remoteArchive}"
+
+if (Test-Path $envPath) {
+    Write-Host "[rf-service] uploading env file $EnvFile"
+    scp -i $resolvedKey $envPath "${sshTarget}:/tmp/rf-service.env"
+} else {
+    Write-Host "[rf-service] env file not found, remote existing .env will be kept: $envPath"
+}
+
+$remoteScript = @"
+set -euo pipefail
+if ! command -v python3 >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y python3 python3-venv python3-pip
+elif ! python3 -m venv --help >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y python3-venv python3-pip
+fi
+sudo mkdir -p "$RemoteRoot"
+sudo tar -xzf "$remoteArchive" -C "$RemoteRoot"
+sudo chown -R "${User}:${User}" "$RemoteRoot"
+cd "$RemoteRoot/apps/ai_api"
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+if [ -f requirements-rf.txt ]; then pip install -r requirements-rf.txt; fi
+if [ -f /tmp/rf-service.env ]; then
+  mv /tmp/rf-service.env "$RemoteRoot/apps/ai_api/.env"
+fi
+sudo tee /etc/systemd/system/$ServiceName.service >/dev/null <<'UNIT'
+[Unit]
+Description=WiFi Capstone RF/AI API
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$RemoteRoot/apps/ai_api
+EnvironmentFile=-$RemoteRoot/apps/ai_api/.env
+Environment=HOST=0.0.0.0
+Environment=PORT=$Port
+ExecStart=$RemoteRoot/apps/ai_api/.venv/bin/python -m uvicorn main:app --host 0.0.0.0 --port $Port
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+sudo systemctl daemon-reload
+sudo systemctl enable $ServiceName
+sudo systemctl restart $ServiceName
+sudo systemctl --no-pager --full status $ServiceName
+sleep 2
+curl -fsS "http://127.0.0.1:$Port/health" >/dev/null || {
+  echo "Health check failed. Recent logs:"
+  sudo journalctl -u $ServiceName -n 80 --no-pager
+  exit 1
+}
+"@
+
+Write-Host "[rf-service] installing and restarting service"
+$remoteScript | ssh -i $resolvedKey $sshTarget "bash -s"
+
+Remove-Item -LiteralPath $archive -Force
+Write-Host "[rf-service] deployed: http://${HostName}:$Port"


### PR DESCRIPTION
## 개요
ai_api의 내부 Sionna 실행 API에 결과 이미지 서빙 기능을 추가하고, Sionna RT가 생성한 heatmap PNG를 프론트엔드에서 <img> 또는 SVG image로 직접 로드할 수 있도록 응답 구조를 개선

## 변경 사항
### 1. Sionna 결과 이미지 서빙 라우트 추가
- apps/ai_api/app/api/routes/sionna.py에 이미지 다운로드용 GET API가 추가

### 2. heatmap PNG를 clean overlay와 annotated debug 이미지로 분리
save_radiomap_png가 이제 2종류의 이미지를 저장하도록 변경
- radiomap_heatmap.png
→ 프론트 캔버스 정렬용 clean overlay

- radiomap_heatmap_annotated.png
→ 사람이 확인하는 디버그용 이미지

### 3.heatmap color scale을 응답 artifact에 포함
프론트엔드의 legend와 실제 heatmap 이미지가 같은 dBm 범위를 기준으로 표시

### 4. ai_api SimulationConfig fallback 기본값 정리
- web-platform이 physical / solver / propagation 값을 명시적으로 채워서 보내는 경우 ai_api의 default는 직접 쓰이지 않고, ai_api를 테스트/CLI 등에서 직접 호출할 때 fallback으로만 사용된다는 의도를 문서화
- PR diff 기준으로 diffuse_reflection, diffraction 기본값이 False에서 True로 변경